### PR TITLE
docs: add note for East Asian Width

### DIFF
--- a/doc/cellwidths.jax
+++ b/doc/cellwidths.jax
@@ -316,7 +316,18 @@ v2.1.0 以前に関しては `"v1.0.0"` のタグを、それより後は SF Mon
 ==============================================================================
 CAVEATS							    *cellwidths-caveats*
 
+					 *cellwidths-caveats-need-setcellwidths*
 このプラグインは |setcellwidths()| を実装した最新の Neovim で動作します。
+
+					 *cellwidths-caveats-east-asian-width-w*
+これは |setcellwidths()| 自体の制限ですが、設定する対象の文字は East Asian Width
+が “W” のものに限られます。
+
+https://ja.wikipedia.org/wiki/東アジアの文字幅
+
+特定の文字について East Asian Width を調べるには |eaw.nvim| を使ってください。
+
+https://github.com/delphinus/eaw.nvim
 
 ==============================================================================
 REFERENCES						 *cellwidths-references*
@@ -327,6 +338,8 @@ REFERENCES						 *cellwidths-references*
   https://github.com/miiton/Cica
 - SF Mono Square フォント
   https://github.com/delphinus/homebrew-sfmono-square
+- delphinus/eaw.nvim: Yet another plugin for East Asian Width characters.
+  https://github.com/delphinus/eaw.nvim
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:noet:


### PR DESCRIPTION
East Asian Width が “W” 以外の文字に使っている例がまま見られたので追記。