### PR TITLE
Fix: vim.tbl_islist is deprecated since 'nvim-0.10' or later

### DIFF
--- a/lua/cellwidths/table.lua
+++ b/lua/cellwidths/table.lua
@@ -25,12 +25,14 @@ function Table:set(cw_table)
   self.cw_table = cw_table
 end
 
+local islist = vim.fn.has("nvim-0.10") == 1 and vim.islist or vim.tbl_islist
+
 ---@return nil
 function Table:clean_up()
   ---@param cw_table any
   ---@return boolean
   local function is_valid_table(cw_table)
-    if type(cw_table) ~= "table" or not vim.tbl_islist(cw_table) then
+    if type(cw_table) ~= "table" or not islist(cw_table) then
       return false
     end
     for _, entry in ipairs(cw_table) do

--- a/lua/cellwidths/table.lua
+++ b/lua/cellwidths/table.lua
@@ -25,7 +25,7 @@ function Table:set(cw_table)
   self.cw_table = cw_table
 end
 
-local islist = vim.fn.has("nvim-0.10") == 1 and vim.islist or vim.tbl_islist
+local islist = vim.islist or vim.tbl_islist
 
 ---@return nil
 function Table:clean_up()


### PR DESCRIPTION
プラグインありがとうございます。

vim.tbl_islistが nvim-0.10 以降Deprecatedなのでその対応です。
参考： https://neovim.io/doc/user/deprecated.html#vim.tbl_islist()